### PR TITLE
recipes.html: Require keyword for recipe search

### DIFF
--- a/layerindex/views.py
+++ b/layerindex/views.py
@@ -656,7 +656,10 @@ class MachineSearchView(ListView):
 
     def get_queryset(self):
         _check_url_branch(self.kwargs)
-        query_string = self.request.GET.get('q', '')
+        if self.request.GET.get('search', ''):
+            query_string = self.request.GET.get('q', '')
+        else:
+            query_string = ""
         init_qs = Machine.objects.filter(layerbranch__branch__name=self.kwargs['branch'])
         if query_string.strip():
             entry_query = simplesearch.get_query(query_string, ['name', 'description'])
@@ -705,7 +708,10 @@ class DistroSearchView(ListView):
 
     def get_queryset(self):
         _check_url_branch(self.kwargs)
-        query_string = self.request.GET.get('q', '')
+        if self.request.GET.get('search', ''):
+            query_string = self.request.GET.get('q', '')
+        else:
+            query_string = ""
         init_qs = Distro.objects.filter(layerbranch__branch__name=self.kwargs['branch'])
         if query_string.strip():
             entry_query = simplesearch.get_query(query_string, ['name', 'description'])
@@ -730,7 +736,10 @@ class ClassSearchView(ListView):
 
     def get_queryset(self):
         _check_url_branch(self.kwargs)
-        query_string = self.request.GET.get('q', '')
+        if self.request.GET.get('search', ''):
+            query_string = self.request.GET.get('q', '')
+        else:
+            query_string = ""
         init_qs = BBClass.objects.filter(layerbranch__branch__name=self.kwargs['branch'])
         if query_string.strip():
             entry_query = simplesearch.get_query(query_string, ['name'])

--- a/templates/layerindex/classes.html
+++ b/templates/layerindex/classes.html
@@ -35,7 +35,8 @@
                     <div class="input-append">
                         <form id="filter-form" action="{% url 'class_search' url_branch %}" method="get">
                             <input type="text" class="input-xxlarge" id="appendedInputButtons" placeholder="Search classes" name="q" value="{{ search_keyword }}" />
-                            <button class="btn" type="submit">search</button>
+                            <button class="btn" type="submit" name="search" value="1">search</button>
+                            <button class="btn" type="submit" name="browse" value="1">browse</button>
                         </form>
                     </div>
                 </div>

--- a/templates/layerindex/distros.html
+++ b/templates/layerindex/distros.html
@@ -35,7 +35,8 @@
                     <div class="input-append">
                         <form id="filter-form" action="{% url 'distro_search' url_branch %}" method="get">
                             <input type="text" class="input-xxlarge" id="appendedInputButtons" placeholder="Search distros" name="q" value="{{ search_keyword }}" />
-                            <button class="btn" type="submit">search</button>
+                            <button class="btn" type="submit" name="search" value="1">search</button>
+                            <button class="btn" type="submit" name="browse" value="1">browse</button>
                         </form>
                     </div>
                 </div>

--- a/templates/layerindex/machines.html
+++ b/templates/layerindex/machines.html
@@ -34,7 +34,8 @@
                     <div class="input-append">
                         <form id="filter-form" action="{% url 'machine_search' url_branch %}" method="get">
                             <input type="text" class="input-xxlarge" id="appendedInputButtons" placeholder="Search machines" name="q" value="{{ search_keyword }}" />
-                            <button class="btn" type="submit">search</button>
+                            <button class="btn" type="submit" name="search" value="1">search</button>
+                            <button class="btn" type="submit" name="browse" value="1">browse</button>
                         </form>
                     </div>
                 </div>

--- a/templates/layerindex/recipes.html
+++ b/templates/layerindex/recipes.html
@@ -32,14 +32,20 @@
 
 
                 <div class="row-fluid">
-                    <div class="input-append">
-                        <form id="filter-form" action="{% url 'recipe_search' url_branch %}" method="get">
-                            <input type="text" class="input-xxlarge" id="appendedInputButtons" placeholder="Search recipes" name="q" value="{{ search_keyword }}" />
-                            <button class="btn" type="submit">search</button>
-                        </form>
-                    </div>
+                    <form id="filter-form" action="{% url 'recipe_search' url_branch %}" method="get" onsubmit="return validate()">
+                        <div class="control-group"  id="searchfield">
+                            <div class="controls">
+                                <div class="input-append">
+                                    <input type="text" class="input-xxlarge" id="appendedInputButtons" placeholder="Search recipes" name="q" value="{{ search_keyword }}" />
+                                    <button class="btn" type="submit">search</button>
+                                </div>
+                                <span class="help-inline" id="errortext"></span>
+                            </div>
+                        </div>
+                    </form>
                 </div>
 
+                <div id="error"> </div>
 {% if recipe_list %}
                 <table class="table table-striped table-bordered recipestable">
                     <thead>
@@ -88,5 +94,14 @@
         $('.icon-hdd').tooltip({title:"Inherits image"});
         $('.label-inverse').tooltip();
     });
+
+    function validate(){
+        if (!$("#appendedInputButtons").val()){
+            $("#errortext").html("<p>Please specify search text</p>");
+            $("#searchfield").addClass("error");
+            return false;
+        }
+    }
+
 </script>
 {% endblock %}


### PR DESCRIPTION
Use JavaScript to check if the search box for recipe search is
empty before querying the database. This will prevent the "502
Bad Gateway" error that occurs when the query takes too long due
to the large list of recipes. Since there are so many recipes
spread across the layers in the OE index, there's no point in
allowing a user to search without a keyword in order to browse
the list; it simply isn't digestible as a whole.

Add a browse button for the Machines, Classes, and Distros pages.

Fixes [YOCTO #11930]

Signed-off-by: Amanda Brindle <amanda.r.brindle@intel.com>